### PR TITLE
fix: Typo in extension pack name

### DIFF
--- a/ExtensionPack/package.json
+++ b/ExtensionPack/package.json
@@ -3,7 +3,7 @@
   "name": "js-notebook-extension-pack",
   "version": "1.0.6",
   "publisher": "GordonSmith",
-  "displayName": "JavsaScript Notebook Extension Pack",
+  "displayName": "JavaScript Notebook Extension Pack",
   "description": "Popular extensions for Observable JavaScript Notebooks in Visual Studio Code.",
   "icon": "LanguageJS_color_128x.png",
   "readme": "README.md",


### PR DESCRIPTION
Thanks for the great work on this extension! Figured fixing this typo may help more people discover it.

`JavsaScript` -> `JavaScript`